### PR TITLE
Implement more complete collection with support for Cisco SD-WAN 19.2 Always On Sandbox

### DIFF
--- a/Cisco-SD-WAN-Environment.postman_environment.json
+++ b/Cisco-SD-WAN-Environment.postman_environment.json
@@ -1,34 +1,144 @@
 {
-  "id": "bff3364e-598f-4890-8e64-c8e93afb2345",
-  "name": "Cisco-SD-WAN-Environment",
-  "values": [
-    {
-      "key": "vmanage",
-      "value": "sandboxsdwan.cisco.com",
-      "description": "",
-      "enabled": true
-    },
-    {
-      "key": "j_username",
-      "value": "devnetuser",
-      "description": "",
-      "enabled": true
-    },
-    {
-      "key": "j_password",
-      "value": "Cisco123!",
-      "description": "",
-      "enabled": true
-    },
-    {
-      "key": "port",
-      "value": "8443",
-      "type": "text",
-      "description": "",
-      "enabled": true
-    }
-  ],
-  "_postman_variable_scope": "environment",
-  "_postman_exported_at": "2018-10-07T04:09:04.277Z",
-  "_postman_exported_using": "Postman/6.3.0"
+	"id": "3d782c01-9c15-463a-be25-6fe10a2001ed",
+	"name": "Cisco DevNet Sandbox Always on",
+	"values": [
+		{
+			"key": "vmanage",
+			"value": "sandbox-sdwan-1.cisco.com",
+			"enabled": true
+		},
+		{
+			"key": "j_username",
+			"value": "devnetuser",
+			"enabled": true
+		},
+		{
+			"key": "j_password",
+			"value": "RG!_Yw919_83",
+			"enabled": true
+		},
+		{
+			"key": "port",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "token",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "count",
+			"value": "100",
+			"enabled": true
+		},
+		{
+			"key": "startDate",
+			"value": "2020-04-21T18:00:00",
+			"enabled": true
+		},
+		{
+			"key": "endDate",
+			"value": "2020-04-21T18:30:00",
+			"enabled": true
+		},
+		{
+			"key": "timeZone",
+			"value": "BST",
+			"enabled": true
+		},
+		{
+			"key": "deviceId",
+			"value": "10.10.20.174",
+			"enabled": true
+		},
+		{
+			"key": "remoteSystemIp",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "localColor",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "remoteColor",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "color",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "systemIp",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "vpnId",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "isCached",
+			"value": "false",
+			"enabled": true
+		},
+		{
+			"key": "state",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "ifName",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "afType",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "prefix",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "nextHop",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "peerAddr",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "as",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "bridgeId",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "macAddress",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "copy_cookie",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-10-30T08:20:41.376Z",
+	"_postman_exported_using": "Postman/7.35.0"
 }

--- a/Cisco-SD-WAN.postman_collection.json
+++ b/Cisco-SD-WAN.postman_collection.json
@@ -1,12 +1,12 @@
 {
 	"info": {
-		"_postman_id": "eb9ea9da-998c-473c-a45d-eb921b13aabc",
+		"_postman_id": "96c5b8ce-f20d-4bf2-b780-3a2494875eee",
 		"name": "Cisco-SD-WAN",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "1.Authentication",
+			"name": "1. Authentication",
 			"item": [
 				{
 					"name": "Authentication",
@@ -46,8 +46,92 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Get Token (19.2)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "218939e0-5882-4614-b40d-6734bd6fbd64",
+								"exec": [
+									"pm.test(\"Response does not contain HTML tag\", function () {",
+									"    pm.expect(pm.response.text()).to.not.include(\"<html>\")",
+									"    pm.environment.set(\"token\", responseBody);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/client/token",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"client",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Logout",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": []
+						},
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/logout?nocache",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"logout"
+							],
+							"query": [
+								{
+									"key": "nocache",
+									"value": null
+								}
+							]
+						}
+					},
+					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "2. SD-WAN Fabric Devices",
@@ -56,11 +140,13 @@
 					"name": "Fabric Devices",
 					"request": {
 						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/device",
 							"protocol": "https",
@@ -80,11 +166,13 @@
 					"name": "Devices Status",
 					"request": {
 						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/device/monitor",
 							"protocol": "https",
@@ -105,11 +193,13 @@
 					"name": "Device Counters",
 					"request": {
 						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/device/counters",
 							"protocol": "https",
@@ -130,11 +220,13 @@
 					"name": "Interface statistics",
 					"request": {
 						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/statistics/interface",
 							"protocol": "https",
@@ -151,7 +243,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "3. SD-WAN Device Template",
@@ -161,10 +254,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/template/feature",
 							"protocol": "https",
@@ -186,10 +275,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/template/feature/types",
 							"protocol": "https",
@@ -207,7 +292,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "4. SD-WAN Device Policy",
@@ -216,11 +302,13 @@
 					"name": "vEdge Template Policy",
 					"request": {
 						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/template/policy/vedge/devices",
 							"protocol": "https",
@@ -243,11 +331,13 @@
 					"name": "Policy List",
 					"request": {
 						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
 						"url": {
 							"raw": "https://{{vmanage}}:{{port}}/dataservice/template/policy/list",
 							"protocol": "https",
@@ -265,7 +355,11264 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "5. Bulk State",
+			"item": [
+				{
+					"name": "BFD Sessions",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/BFDSessions?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"BFDSessions"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "BGP Neighbor",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/BGPNeighbor?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"BGPNeighbor"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Control Connection",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/ControlConnection?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"ControlConnection"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Control Local Property",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/ControlLocalProperty?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"ControlLocalProperty"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Control WAN Interface",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/ControlWanInterface?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"ControlWanInterface"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Hardware Alarms",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/HardwareAlarms?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"HardwareAlarms"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Hardware Environment",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/HardwareEnvironment?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"HardwareEnvironment"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Hardware Inventory",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/HardwareInventory?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"HardwareInventory"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Interface",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/Interface",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"Interface"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "CEdge Interface",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"type": "text",
+								"value": "{{token}}"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/CEdgeInterface",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"CEdgeInterface"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "OMP Peers",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/OMPPeer?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"OMPPeer"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "System Status",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/SystemStatus?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"SystemStatus"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "System",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/state/System?count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"state",
+								"System"
+							],
+							"query": [
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "6. Bulk Statistics (min 20min period)",
+			"item": [
+				{
+					"name": "Alarms",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/alarm?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"alarm"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Application-Aware Routing Status",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/approutestatsstatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"approutestatsstatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Audit Logs",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/auditlog?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"auditlog"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Bridge Interfaces",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/bridgeinterfacestatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"bridgeinterfacestatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Bridge MAC Addresses",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/bridgemacstatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"bridgemacstatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "CloudExpress Service",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/cloudxstatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"cloudxstatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Device Configuration",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/deviceconfiguration?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"deviceconfiguration"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Device Events",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/deviceevents?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"deviceevents"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Device System Status",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/devicesystemstatusstatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"devicesystemstatusstatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DPI",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/dpistatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"dpistatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Flow Logs",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/flowlogstatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"flowlogstatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Interfaces",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/interfacestatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"interfacestatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "WLAN Clients",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/wlanclientinfostatistics?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"wlanclientinfostatistics"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "?urlf?",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/urlf?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"urlf"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "?fwall?",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/fwall?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"fwall"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "?umbrella?",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/umbrella?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"umbrella"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "?ipsalert?",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/ipsalert?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"ipsalert"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "?speedtest?",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-XSRF-TOKEN",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "https://{{vmanage}}:{{port}}/dataservice/data/device/statistics/speedtest?startDate={{startDate}}&endDate={{endDate}}&timeZone={{timeZone}}&count={{count}}",
+							"protocol": "https",
+							"host": [
+								"{{vmanage}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"dataservice",
+								"data",
+								"device",
+								"statistics",
+								"speedtest"
+							],
+							"query": [
+								{
+									"key": "startDate",
+									"value": "{{startDate}}"
+								},
+								{
+									"key": "endDate",
+									"value": "{{endDate}}"
+								},
+								{
+									"key": "timeZone",
+									"value": "{{timeZone}}"
+								},
+								{
+									"key": "count",
+									"value": "{{count}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "7. Real-Time Monitoring",
+			"item": [
+				{
+					"name": "Application-Aware Route",
+					"item": [
+						{
+							"name": "Retrieve application-aware statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-route/statistics?deviceId={{deviceId}}&remote-system-ip={{remoteSystemIp}}&local-color={{localColor}}&remote-color={{remoteColor}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-route",
+										"statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-system-ip",
+											"value": "{{remoteSystemIp}}",
+											"description": "(optional)"
+										},
+										{
+											"key": "local-color",
+											"value": "{{localColor}}",
+											"description": "(optional)"
+										},
+										{
+											"key": "remote-color",
+											"value": "{{remoteColor}}",
+											"description": "(optional)"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve SLA class list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-route/sla-class?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-route",
+										"sla-class"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "ARP",
+					"item": [
+						{
+							"name": "Retrieve ARP interfaces",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/arp?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"arp"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "BFD",
+					"item": [
+						{
+							"name": "Retrieve BFD summary from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of BFD sessions from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/sessions?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"sessions"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "system-ip",
+											"value": "{{systemIp}}",
+											"disabled": true
+										},
+										{
+											"key": "color",
+											"value": "{{color}}",
+											"disabled": true
+										},
+										{
+											"key": "local-color",
+											"value": "{{localColor}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of BFD sessions from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/synced/sessions?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"synced",
+										"sessions"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "system-ip",
+											"value": "{{systemIp}}",
+											"disabled": true
+										},
+										{
+											"key": "color",
+											"value": "{{color}}",
+											"disabled": true
+										},
+										{
+											"key": "local-color",
+											"value": "{{localColor}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve BFD session history from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/history?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"history"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "system-ip",
+											"value": "{{systemIp}}",
+											"disabled": true
+										},
+										{
+											"key": "color",
+											"value": "{{color}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve BFD summary from device (tloc)",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/tloc?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"tloc"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve BFD site summary",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/sites/summary?isCached={{isCached}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"sites",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "isCached",
+											"value": "{{isCached}}"
+										},
+										{
+											"key": "vpnId",
+											"value": "{{vpnId}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve detailed BFD site summary",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/sites/detail",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"sites",
+										"detail"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device BFD status summary",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/summary/device?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"summary",
+										"device"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device BFD state summary",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/state/device?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"state",
+										"device"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get device BFD status",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/status",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"status"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of BFD connections",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/links?state={{state}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"links"
+									],
+									"query": [
+										{
+											"key": "state",
+											"value": "{{state}}",
+											"description": "up/down/not-available"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device BFD state summary with tloc color dia",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bfd/state/device/tloc?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bfd",
+										"state",
+										"device",
+										"tloc"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "BGP",
+					"item": [
+						{
+							"name": "Retrieve BGP summary from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bgp/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bgp",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of BGP routes from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bgp/routes?deviceId={{deviceId}}&vpn-id={{vpnId}}&prefix&nexthop",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bgp",
+										"routes"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}"
+										},
+										{
+											"key": "prefix",
+											"value": null
+										},
+										{
+											"key": "nexthop",
+											"value": null
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of BGP neighbors from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bgp/neighbors?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bgp",
+										"neighbors"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "peer-addr",
+											"value": "{{peerAddr}}",
+											"description": "Peer address",
+											"disabled": true
+										},
+										{
+											"key": "as",
+											"value": "{{as}}",
+											"description": "AS number",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Bridge",
+					"item": [
+						{
+							"name": "Retrieve brdige mac from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bridge/mac?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bridge",
+										"mac"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "bridge-id",
+											"value": "{{bridgeId}}",
+											"disabled": true
+										},
+										{
+											"key": "if-name",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "mac-address",
+											"value": "{{macAddress}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve bridge interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bridge/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bridge",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve bridge interface table from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/bridge/table?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"bridge",
+										"table"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Cellular",
+					"item": [
+						{
+							"name": "Retrieve cellular status list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cellular modem list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/modem?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"modem"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cellular radio list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/radio?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"radio"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cellular network list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/network?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"network"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cellular hardware list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/hardware?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"hardware"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cellular connection list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/connection?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"connection"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cellular profile list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/profiles?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"profiles"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cellular sessions list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cellular/sessions?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cellular",
+										"sessions"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "if-name",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "ipv4-dns-pri",
+											"value": null,
+											"description": "DNS Primary IP",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "CloudExpress",
+					"item": [
+						{
+							"name": "Retrieve list of cloudexpress applications from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cloudx/applications?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cloudx",
+										"applications"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "application",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of cloudexpress local exits from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cloudx/localexits?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cloudx",
+										"localexits"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "application",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of cloudexpress gateway exits from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/cloudx/gatewayexits?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"cloudx",
+										"gatewayexits"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "application",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Crash Log",
+					"item": [
+						{
+							"name": "Retrieve crash logs for all devices",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/crashlog/details",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"crashlog",
+										"details"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device crash logs from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/crashlog?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"crashlog"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device crash logs from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/crashlog/synced?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"crashlog",
+										"synced"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve crash information",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/crashlog/log?deviceId={{deviceId}}&filename",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"crashlog",
+										"log"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}",
+											"description": "(required)"
+										},
+										{
+											"key": "filename",
+											"value": null,
+											"description": "(required)"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Device Control",
+					"item": [
+						{
+							"name": "Retrieve list of unreachable devices",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/networksummary",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"networksummary"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connections summary from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device control status summary",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/summary/device?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"summary",
+										"device"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device status",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/status",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"status"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connections list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/links?state={{state}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"links"
+									],
+									"query": [
+										{
+											"key": "state",
+											"value": "{{state}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connections list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/synced/connections?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"synced",
+										"connections"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "peer-type",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "system-ip",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connections list history from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/connectionshistory?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"connectionshistory"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "peer-type",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "system-ip",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "local-color",
+											"value": "{{localColor}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve valid vSmart list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/validvsmarts?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"validvsmarts"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve valid vManage from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/validvmanageid?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"validvmanageid"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve valid device list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/validdevices?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"validdevices"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve WAN interface list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/waninterface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"waninterface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve WAN interface list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/synced/waninterface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"synced",
+										"waninterface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve local properties list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/localproperties?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"localproperties"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve local properties list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/synced/localproperties?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"synced",
+										"localproperties"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve total counts of device states",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/count?isCached={{isCached}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"count"
+									],
+									"query": [
+										{
+											"key": "isCached",
+											"value": "{{isCached}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve port hop colors",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/waninterface/color?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"waninterface",
+										"color"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve affinity config from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/affinity/config?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"affinity",
+										"config"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve affinity status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/affinity/status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"affinity",
+										"status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connection statistics from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connections list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/control/connections?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"control",
+										"connections"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "peer-type",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "system-ip",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Device Users",
+					"item": [
+						{
+							"name": "Retrieve users list logged in users",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/users/list?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"users",
+										"list"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of users from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/users?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"users"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "DHCP",
+					"item": [
+						{
+							"name": "Retrieve DHCP client entries from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dhcp/client?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dhcp",
+										"client"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve DHCP server entries from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dhcp/server?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dhcp",
+										"server"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve DHCP interfaces from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dhcp/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dhcp",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve DHCPv6 interfaces from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dhcpv6/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dhcpv6",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "DPI",
+					"item": [
+						{
+							"name": "Retrieve DPI applications from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/applications?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"applications"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "application",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "family",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve list of supported applications from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/supported-applications?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"supported-applications"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "application",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "family",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve DPI query field JSON",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/application/fields?isDeviceDashboard=false",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"application",
+										"fields"
+									],
+									"query": [
+										{
+											"key": "isDeviceDashboard",
+											"value": "false"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device DPI query field JSON",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/device/fields",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"device",
+										"fields"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve flows list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/flows?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"flows"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "src-ip",
+											"value": "",
+											"disabled": true
+										},
+										{
+											"key": "application",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "family",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve summary from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve qosmos application list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/qosmos/applications",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"qosmos",
+										"applications"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve common application list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/common/applications",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"common",
+										"applications"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve detailed DPI querty field JSON",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dpi/devicedetails/fields",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dpi",
+										"devicedetails",
+										"fields"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Hardware",
+					"item": [
+						{
+							"name": "Retrieve hardware status summary",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/status/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"status",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware errored alarm list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/errors",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"errors"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware alarm list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/alarms?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"alarms"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware alarm list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/synced/alarms?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"synced",
+										"alarms"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware system data list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/system?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"system"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware inventory list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/inventory?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"inventory"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware inventory list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/synced/inventory?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"synced",
+										"inventory"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware environment list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/environment?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"environment"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware environment list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/synced/environment?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"synced",
+										"environment"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve hardware temperature threshold list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/hardware/threshold?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"hardware",
+										"threshold"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "IGMP",
+					"item": [
+						{
+							"name": "Retrieve IGMP statistics list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/igmp/statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"igmp",
+										"statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IGMP Rp-mapping list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/igmp/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"igmp",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IGMP interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/igmp/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"igmp",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IGMP neighbor list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/igmp/groups?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"igmp",
+										"groups"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Interface",
+					"item": [
+						{
+							"name": "Retrieve interfaces from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/synced?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"synced"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interfaces per VPN",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/vpn?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"vpn"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interfaces ARP statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/arp_stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"arp_stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interfaces serial ?",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/serial?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"serial"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interface error statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/error_stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"error_stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interface packet size statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/pkt_size?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"pkt_size"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interface port statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/port_stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"port_stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interface queue statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/queue_stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"queue_stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interface statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interface IPv6 statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface/ipv6Stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface",
+										"ipv6Stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve interfaces from Device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "ifname",
+											"value": "{{ifName}}",
+											"disabled": true
+										},
+										{
+											"key": "af-type",
+											"value": "{{afType}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "IP",
+					"item": [
+						{
+							"name": "Retrieve FIB list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/fib?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"fib"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "address-family",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "prefix",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "tloc",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "color",
+											"value": "{{color}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve cedge_cef from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/cedge_cef?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"cedge_cef"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "ip-addr",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "af",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve route table list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/routetable?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"routetable"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "address-family",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "prefix",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "protocol",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IP MFIB OIL list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/mfiboil?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"mfiboil"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IP MFIB statistics from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/mfibstats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"mfibstats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Generate IP MFIB summary list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/mfibsummary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"mfibsummary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NAT interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/nat/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"nat",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NAT translation list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/nat/translation?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"nat",
+										"translation"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NAT filter list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/nat/filter?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"nat",
+										"filter"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "nat-vpn-id",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "nat-ifname",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "private-source-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "proto",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NAT interface statistics from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/nat/interfacestatistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"nat",
+										"interfacestatistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NAT64 interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/nat64/translation?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"nat64",
+										"translation"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve ietf routing list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ip/ipRoutes?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ip",
+										"ipRoutes"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "name",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "address-family",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "destination-prefix",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "outgoing-interface",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "source-protocol",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "next-hop-address",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "IPSEC",
+					"item": [
+						{
+							"name": "Retrieve IPsec inbound connection list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/inbound?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"inbound"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "local-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec outbound connection list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/outbound?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"outbound"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec local SA list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/localsa?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"localsa"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec IKE inbound connection list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/ike/inbound?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"ike",
+										"inbound"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec IKE outbound connection list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/ike/outbound?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"ike",
+										"outbound"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec IKE sessions",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/ike/sessions?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"ike",
+										"sessions"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve Crypto IPsec identity entry from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/identity?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"identity"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "local-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve Crypto IPsec IKEv1 SA entry from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/ikev1?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"ikev1"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve Crypto IPsec IKEv2 SA entry from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/ikev2?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"ikev2"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec Pairwise Key Local SA entry from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/pwk/localsa?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"pwk",
+										"localsa"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "local-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec Pairwise Key Inbound entry from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/pwk/inbound?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"pwk",
+										"inbound"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "local-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPsec Pairwise Key Outbound entry from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ipsec/pwk/outbound?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ipsec",
+										"pwk",
+										"outbound"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "local-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Multicast",
+					"item": [
+						{
+							"name": "Retrieve RPF list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/multicast/rpf?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"multicast",
+										"rpf"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve replicator list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/multicast/replicator?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"multicast",
+										"replicator"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve topology list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/multicast/topology?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"multicast",
+										"topology"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve PIM tunnel list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/multicast/tunnel?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"multicast",
+										"tunnel"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "NTP",
+					"item": [
+						{
+							"name": "Retrieve NTP peer associations list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ntp/associations?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ntp",
+										"associations"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NTP peer status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ntp/status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ntp",
+										"status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NTP peer list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ntp/peer?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ntp",
+										"peer"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "IPv6 Neighbors",
+					"item": [
+						{
+							"name": "Retrieve IPv6 Neighbors from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ndv6?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ndv6"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "vpn-id",
+											"value": "{{vpnId}}",
+											"disabled": true
+										},
+										{
+											"key": "if-name",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "mac",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "OMP",
+					"item": [
+						{
+							"name": "Retrieve OMP session list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/peers?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"peers"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP session list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/synced/peers?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"synced",
+										"peers"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP received routes list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/routes/received?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"routes",
+										"received"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP advertised routes list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/routes/advertised?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"routes",
+										"advertised"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve received TLOCs list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/tlocs/received?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"tlocs",
+										"received"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve advertised TLOCs list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/tlocs/advertised?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"tlocs",
+										"advertised"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device OMP status",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP connection list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/links",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"links"
+									],
+									"query": [
+										{
+											"key": "state",
+											"value": "{{state}}",
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP summary",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP services list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/services?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"services"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP multicast autodiscover received list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/mcastautodiscoverrecv?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"mcastautodiscoverrecv"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP multicast autodiscover advertised list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/mcastautodiscoveradvt?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"mcastautodiscoveradvt"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP multicast routes received list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/mcastroutesrecv?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"mcastroutesrecv"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OMP multicast routes advertised list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/mcastroutesadvt?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"mcastroutesadvt"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve CloudExpress routes received list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/omp/cloudx?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"omp",
+										"cloudx"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Orchestrator",
+					"item": [
+						{
+							"name": "Retrieve connections summary from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve reverse proxy mapping from vbond",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/proxymapping?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"proxymapping"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connection history list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/connectionshistory?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"connectionshistory"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve valid vSmart list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/validvsmarts?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"validvsmarts"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve valid vManage ID from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/validvmanageid?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"validvmanageid"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve valid device list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/validvedges?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"validvedges"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve local properties list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/localproperties?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"localproperties"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve connection list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/orchestrator/connections?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"orchestrator",
+										"connections"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "OSPF",
+					"item": [
+						{
+							"name": "Retrieve OSPF neighbor list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ospf/neighbor?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ospf",
+										"neighbor"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OSPF route list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ospf/routes?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ospf",
+										"routes"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OSPF database list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ospf/database?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ospf",
+										"database"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OSPF process list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ospf/process?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ospf",
+										"process"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OSPF interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ospf/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ospf",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OSPF database summary list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ospf/databasesummary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ospf",
+										"databasesummary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve OSPF external database list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ospf/databaseexternal?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ospf",
+										"databaseexternal"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "PIM",
+					"item": [
+						{
+							"name": "Retrieve PIM Rp-mapping list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/pim/rp-mapping?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"pim",
+										"rp-mapping"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve PIM interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/pim/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"pim",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve PIM neighbor list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/pim/neighbor?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"pim",
+										"neighbor"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve PIM statistics list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/pim/statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"pim",
+										"statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve PPP interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ppp/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ppp",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Policer",
+					"item": [
+						{
+							"name": "Retrieve policed interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policer?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policer"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Policy",
+					"item": [
+						{
+							"name": "Retrieve access list associations from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/accesslistassociations?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"accesslistassociations"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve access list counters from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/accesslistcounters?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"accesslistcounters"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve access list names from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/accesslistnames?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"accesslistnames"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve access list policers from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/accesslistpolicers?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"accesslistpolicers"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPv6 access list associations from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/ipv6/accesslistassociations?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"ipv6",
+										"accesslistassociations"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPv6 access list counters from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/ipv6/accesslistcounters?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"ipv6",
+										"accesslistcounters"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPv6 access list names from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/ipv6/accesslistnames?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"ipv6",
+										"accesslistnames"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve IPv6 access list policers from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/ipv6/accesslistpolicers?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"ipv6",
+										"accesslistpolicers"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve data policy filters from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/datapolicyfilter?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"datapolicyfilter"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve app route policy filters from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/approutepolicyfilter?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"approutepolicyfilter"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve QoS map information from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/qosmapinfo?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"qosmapinfo"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve QoS scheduler information from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/qosschedulerinfo?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"qosschedulerinfo"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve rewrite associations information from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/rewriteassociations?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"rewriteassociations"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve zone based firewall statistics from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/zbfwstatistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"zbfwstatistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve zone policy zone pair sessions from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/zonepairsessions?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"zonepairsessions"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve zone policy filter information from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/zonepolicyfilter?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"zonepolicyfilter"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve zone based firewall statistics from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/zbfwdropstatistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"zbfwdropstatistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve zone pair statistics from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/policy/zonepairstatistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"policy",
+										"zonepairstatistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "PPPoE",
+					"item": [
+						{
+							"name": "Retrieve PPPoE session list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/pppoe/session?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"pppoe",
+										"session"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve PPPoE statistics list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/pppoe/statistic?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"pppoe",
+										"statistic"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Reboot History",
+					"item": [
+						{
+							"name": "Retrieve detailed reboot history list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/reboothistory/details",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"reboothistory",
+										"details"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve reboot history list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/reboothistory/synced",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"reboothistory",
+										"synced"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve reboot history list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/reboothistory?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"reboothistory"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Security",
+					"item": [
+						{
+							"name": "Retrieve security information all devices from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/security/information?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"security",
+										"information"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Software",
+					"item": [
+						{
+							"name": "Retrieve software list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/software?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"software"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve software list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/software/synced?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"software",
+										"synced"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "TCP Optimization",
+					"item": [
+						{
+							"name": "Retrieve TCP optimization summary from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tcpopt/summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tcpopt",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve TCP optimization expired flows from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tcpopt/expiredflows?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tcpopt",
+										"expiredflows"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve TCP optimization active flows from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tcpopt/activeflows?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tcpopt",
+										"activeflows"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Transport",
+					"item": [
+						{
+							"name": "Retrieve transport connection list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/transport/connection?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"transport",
+										"connection"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Tunnel",
+					"item": [
+						{
+							"name": "Retrieve tunnel statistics all devices from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tunnel/statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tunnel",
+										"statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve tunnel BFD statistics all devices from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tunnel/bfd_statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tunnel",
+										"bfd_statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve tunnel IPSec statistics all devices from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tunnel/ipsec_statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tunnel",
+										"ipsec_statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve tunnel GRE keepalives information",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tunnel/gre-keepalives?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tunnel",
+										"gre-keepalives"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve tunnel statistics packet duplication",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tunnel/packet-duplicate?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tunnel",
+										"packet-duplicate"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve tunnel fec statistics",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/tunnel/fec_statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"tunnel",
+										"fec_statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "VPN",
+					"item": [
+						{
+							"name": "Retrieve VPN instance list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/vpn?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"vpn"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "VRRP",
+					"item": [
+						{
+							"name": "Retrieve VRRP interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/vrrp?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"vrrp"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "WLAN",
+					"item": [
+						{
+							"name": "Retrieve WLAN Radios from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/wlan/radios?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"wlan",
+										"radios"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve WLAN client from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/wlan/clients?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"wlan",
+										"clients"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve WLAN RADIUS authentication information",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/wlan/radius?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"wlan",
+										"radius"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve WLAN interfaces from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/wlan/interfaces?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"wlan",
+										"interfaces"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "App logs",
+					"item": [
+						{
+							"name": "Retrieve App Log Flows from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app/log/flows?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app",
+										"log",
+										"flows"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Log Flow counts from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app/log/flow-count?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app",
+										"log",
+										"flow-count"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "DOT1x",
+					"item": [
+						{
+							"name": "Retrieve DOT1x radius from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dot1x/radius?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dot1x",
+										"radius"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve DOT1x clients from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dot1x/clients?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dot1x",
+										"clients"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve DOT1x interfaces from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/dot1x/interfaces?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"dot1x",
+										"interfaces"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "AAA",
+					"item": [
+						{
+							"name": "Retrieve ACL match counters from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/acl/matchcounter?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"acl",
+										"matchcounter"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "App Hosting",
+					"item": [
+						{
+							"name": "Retrieve App Hosting Storage Utilization from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/storage-utilization?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"storage-utilization"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Hosting Processes from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/processes?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"processes"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Hosting Utilization from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/utilization?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"utilization"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Hosting Network Utilization from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/network-utilization?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"network-utilization"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Hosting details from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/details?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"details"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Hosting Attached Devices from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/attached-devices?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"attached-devices"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Hosting Network Interfaces from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/network-interfaces?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"network-interfaces"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve App Hosting Guest Routes from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/app-hosting/guest-routes?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"app-hosting",
+										"guest-routes"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "UTD",
+					"item": [
+						{
+							"name": "Retrieve UTD Signature version information from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/signature/version/details?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"signature",
+										"version",
+										"details"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD Engine Instance Status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/engine-instance-status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"engine-instance-status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD File Reputation Status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/file-reputation-status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"file-reputation-status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD File Analysis Status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/file-analysis-status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"file-analysis-status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD IPS Update Status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/ips-update-status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"ips-update-status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD URLF Update Status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/urlf-update-status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"urlf-update-status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD Dataplane Config from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/dataplane-config?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"dataplane-config"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD Dataplane Global from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/dataplane-global?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"dataplane-global"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD Dataplane Stats from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/dataplane-stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"dataplane-stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD Dataplane Stats Summary from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/dataplane-stats-summary?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"dataplane-stats-summary"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD Version Status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/version-status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"version-status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve UTD Engine Status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/utd/engine-status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"utd",
+										"engine-status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Umbrella",
+					"item": [
+						{
+							"name": "Retrieve Umbrella dp-stats from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/umbrella/dp-stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"umbrella",
+										"dp-stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve Umbrella Overview from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/umbrella/overview?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"umbrella",
+										"overview"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve Umbrella Device Registration from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/umbrella/device-registration?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"umbrella",
+										"device-registration"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "VDSL Service",
+					"item": [
+						{
+							"name": "Retrieve VDSL Service CO stats from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/vdslService/coStats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"vdslService",
+										"coStats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve VDSL Service info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/vdslService/vdslInfo?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"vdslService",
+										"vdslInfo"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve VDSL Service CPE stats from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/vdslService/cpeStats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"vdslService",
+										"cpeStats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "VM",
+					"item": [
+						{
+							"name": "Retrieve vm detail from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/vm/state?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"vm",
+										"state"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "rbac",
+					"item": [
+						{
+							"name": "Retrieve Rbac interfaces from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/rbac?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"rbac"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve pnic stats from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/pnic/synced?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"pnic",
+										"synced"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve pnic interfaces from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/pnic?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"pnic"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "System",
+					"item": [
+						{
+							"name": "Retrieve device system process list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/system/processlist?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"system",
+										"processlist"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device system native settings from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/system/native?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"system",
+										"native"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device system settings from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/system/settings?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"system",
+										"settings"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device system settings status from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/system/status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"system",
+										"status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device information list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/system/info?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"system",
+										"info"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device system status list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/system/status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"system",
+										"status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device system statistics from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/system/statistics?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"system",
+										"statistics"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve device system status list from vManage",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/system/synced/status?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"system",
+										"synced",
+										"status"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "NetworkHub Resources",
+					"item": [
+						{
+							"name": "Retrieve NetworkHub CPU VNF info",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/resources/cpu-info/vnfs?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"resources",
+										"cpu-info",
+										"vnfs"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NetworkHub CPU info",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/resources/cpu-info/cpus?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"resources",
+										"cpu-info",
+										"cpus"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve NetworkHub CPU allocation info",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/resources/cpu-info/allocation?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"resources",
+										"cpu-info",
+										"allocation"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Container Lifecycle",
+					"item": [
+						{
+							"name": "Retrieve device process status list",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/csp/containers/container?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"csp",
+										"containers",
+										"container"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "License info",
+					"item": [
+						{
+							"name": "Retrieve license udi info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/license/udi?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"license",
+										"udi"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve license registration info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/license/registration?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"license",
+										"registration"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve license privacy info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/license/privacy?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"license",
+										"privacy"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve license usage info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/license/usage?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"license",
+										"usage"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve pak license info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/license/pak?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"license",
+										"pak"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve license evaluation info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/license/evaluation?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"license",
+										"evaluation"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Ucse",
+					"item": [
+						{
+							"name": "Retrieve UCSE stats entry from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/ucse/stats?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"ucse",
+										"stats"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										},
+										{
+											"key": "remote-tloc-address",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "remote-tloc-color",
+											"value": null,
+											"disabled": true
+										},
+										{
+											"key": "local-tloc-color",
+											"value": null,
+											"disabled": true
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "EIGRP",
+					"item": [
+						{
+							"name": "Retrieve EIGRP topology info from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/eigrp/topology?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"eigrp",
+										"topology"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve EIGRP interface list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/eigrp/interface?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"eigrp",
+										"interface"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve EIGRP route list from device",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-XSRF-TOKEN",
+										"type": "text",
+										"value": "{{token}}"
+									}
+								],
+								"url": {
+									"raw": "https://{{vmanage}}:{{port}}/dataservice/device/eigrp/route?deviceId={{deviceId}}",
+									"protocol": "https",
+									"host": [
+										"{{vmanage}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"dataservice",
+										"device",
+										"eigrp",
+										"route"
+									],
+									"query": [
+										{
+											"key": "deviceId",
+											"value": "{{deviceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"protocolProfileBehavior": {},
+					"_postman_isSubFolder": true
+				}
+			],
+			"protocolProfileBehavior": {}
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,36 @@
-# Postman for Cisco SD-WAN
+# Postman for Cisco SD-WAN 19.x
 
-This public repo contains a [POSTMAN](https://getpostman.com) environment and collection that can be used to interact with the `Cisco SD-WAN powered by Viptela vManage REST API`. The environment is pre-configured to access the [Cisco DevNet Always On Sandbox for SD-WAN](https://sandboxsdwan.cisco.com:8443) fabric. You can edit the variables in the environment to point to your own vManage instance. The collection contains REST API calls to authenticate, get a list of devices that are part of the SD-WAN fabric, and get device status, counters, and interface statistics for all the interfaces in the fabric. Feel free to modify them as you see fit and to add more calls to the collection.
+This public repo contains a [POSTMAN](https://getpostman.com) [environment](Cisco-SD-WAN-Environment.postman_environment.json) and [collection](Cisco-SD-WAN.postman_collection.json) that can be used to interact with the `Cisco SD-WAN 19.2 vManage REST API`. The environment is pre-configured to access the [Cisco DevNet: Cisco SD-WAN 19.2 Always On Sandbox for SD-WAN](https://sandbox-sdwan-1.cisco.com) fabric. You can edit the variables in the environment to point to your own vManage instance.
 
-# Requirements
+## API Calls in this Collection
+
+This collection only includes calls to read (GET) information from the environment. It does not write changes to the vManage environment. The collection provides the following REST API calls to:
+
+- Authenticate
+  - Credentials provided in the [environment](Cisco-SD-WAN-Environment.postman_environment.json) are for the Always On environment.
+  - Obtain X-XSRF-TOKEN to protect against [Cross-Site Request Forgery](https://www.cisco.com/c/en/us/td/docs/routers/sdwan/configuration/sdwan-xe-gs-book/cisco-sd-wan-API-cross-site-request-forgery-prevention.html)
+    - Required for SD-WAN 19.2 and later. The collection automatically stores the token for later calls.
+- List devices that are part of the SD-WAN fabric and show device status, counters, and interface statistics for all the interfaces in the fabric.
+- List device templates
+- List device policy
+- Bulk API requests:
+  - State [Bulk State API Documentation](https://sdwan-docs.cisco.com/Product_Documentation/Command_Reference/Command_Reference/vManage_REST_APIs/Bulk_APIs/Overview_of_Bulk_API_Operations)
+    - Includes an undocumented endpoint (`/dataservice/data/device/state/CEdgeInterface`) for obtaining a list of all interfaces on Cisco IOS XE Routers including i.e. Cisco ISR and also cloud hosted CSR devices.
+  - Statistics [Bulk Statistics API Documentation](https://sdwan-docs.cisco.com/Product_Documentation/Command_Reference/Command_Reference/vManage_REST_APIs/Bulk_APIs/Statistics)
+    - _Data lags real-time by ~20mins_
+- Real-Time monitoring [Real-Time Monitoring API Docuumentation](https://sdwan-docs.cisco.com/Product_Documentation/Command_Reference/Command_Reference/vManage_REST_APIs/Real-Time_Monitoring_APIs)
+
+Feel free to modify them as you see fit and to add more calls to the collection.
+
+## Requirements
 
 The Postman collection and environment will need:
-* Postman 6.4.4+
-* Cisco SD-WAN powered by Viptela vManage 18+
 
-# Setup
+- Postman 6.4.4+
+- Cisco SD-WAN powered by Viptela vManage 19.x or later
+- If using version 18.x, the API uses port `8443` instead of the standard port `443`. This collection _should_ work with an 18.x environment if the environment variable `port` is set.
+
+## Setup
 
 If you don't have Postman already installed, you can download it from [here](https://getpostman.com). Once you install it, you can follow the steps below to import the collection and environment:
 
@@ -20,9 +42,10 @@ If you don't have Postman already installed, you can download it from [here](htt
 2. Make sure you select the `Cisco-SD-WAN-Environment` environment
 3. Expand the collection and start making REST API calls.
 
-
 You can also export the API call into your preferred programming language, like Python or Go.
 
 ![codesnip](./code_snip.png)
 
-### Note: In case your instance of vManage has a self signed certificate, make sure you disable `SSL certificate verification` in Postman's settings.
+## Using self-signed certificate
+
+In case your instance of vManage has a self signed certificate, you can disable `SSL certificate verification` in Postman's settings (File -> Settings -> General -> SSL certificate verification).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Postman for Cisco SD-WAN 19.x
+# Postman for Cisco SD-WAN
 
 This public repo contains a [POSTMAN](https://getpostman.com) [environment](Cisco-SD-WAN-Environment.postman_environment.json) and [collection](Cisco-SD-WAN.postman_collection.json) that can be used to interact with the `Cisco SD-WAN 19.2 vManage REST API`. The environment is pre-configured to access the [Cisco DevNet: Cisco SD-WAN 19.2 Always On Sandbox for SD-WAN](https://sandbox-sdwan-1.cisco.com) fabric. You can edit the variables in the environment to point to your own vManage instance.
 
@@ -8,8 +8,6 @@ This collection only includes calls to read (GET) information from the environme
 
 - Authenticate
   - Credentials provided in the [environment](Cisco-SD-WAN-Environment.postman_environment.json) are for the Always On environment.
-  - Obtain X-XSRF-TOKEN to protect against [Cross-Site Request Forgery](https://www.cisco.com/c/en/us/td/docs/routers/sdwan/configuration/sdwan-xe-gs-book/cisco-sd-wan-API-cross-site-request-forgery-prevention.html)
-    - Required for SD-WAN 19.2 and later. The collection automatically stores the token for later calls.
 - List devices that are part of the SD-WAN fabric and show device status, counters, and interface statistics for all the interfaces in the fabric.
 - List device templates
 - List device policy
@@ -18,7 +16,7 @@ This collection only includes calls to read (GET) information from the environme
     - Includes an undocumented endpoint (`/dataservice/data/device/state/CEdgeInterface`) for obtaining a list of all interfaces on Cisco IOS XE Routers including i.e. Cisco ISR and also cloud hosted CSR devices.
   - Statistics [Bulk Statistics API Documentation](https://sdwan-docs.cisco.com/Product_Documentation/Command_Reference/Command_Reference/vManage_REST_APIs/Bulk_APIs/Statistics)
     - _Data lags real-time by ~20mins_
-- Real-Time monitoring [Real-Time Monitoring API Docuumentation](https://sdwan-docs.cisco.com/Product_Documentation/Command_Reference/Command_Reference/vManage_REST_APIs/Real-Time_Monitoring_APIs)
+- Real-Time monitoring [Real-Time Monitoring API Documentation](https://sdwan-docs.cisco.com/Product_Documentation/Command_Reference/Command_Reference/vManage_REST_APIs/Real-Time_Monitoring_APIs)
 
 Feel free to modify them as you see fit and to add more calls to the collection.
 
@@ -27,8 +25,9 @@ Feel free to modify them as you see fit and to add more calls to the collection.
 The Postman collection and environment will need:
 
 - Postman 6.4.4+
-- Cisco SD-WAN powered by Viptela vManage 19.x or later
-- If using version 18.x, the API uses port `8443` instead of the standard port `443`. This collection _should_ work with an 18.x environment if the environment variable `port` is set.
+- Cisco SD-WAN vManage 18.x or later
+  - If using version 18.x, the API uses port `8443` instead of the standard port `443`. This collection _should_ work with an 18.x environment if the environment variable `port` is set.
+  - If using version 19.2 or later, after authenticating with a username and password, another request is required to obtain a X-XSRF-TOKEN to protect against [Cross-Site Request Forgery](https://www.cisco.com/c/en/us/td/docs/routers/sdwan/configuration/sdwan-xe-gs-book/cisco-sd-wan-API-cross-site-request-forgery-prevention.html). When using this collection the token is automatically stored in a postman environment variable and used with further requests.
 
 ## Setup
 


### PR DESCRIPTION
This update includes changes to the existing calls specifically to work with the Cisco SD-WAN 19.2 Always On DevNet sandbox environment. This includes the addition of an extra call in authentication to obtain a token.

The collection is further expanded with all the known endpoints I could find documented for obtaining data from vManage.

Hope you and others find this useful.